### PR TITLE
Add org-level overrides to CourseWaffleFlag docs.

### DIFF
--- a/docs/how_to/implement_the_right_toggle_type.rst
+++ b/docs/how_to/implement_the_right_toggle_type.rst
@@ -140,7 +140,7 @@ If you are wrapping a legacy flag that does not have a namespaced name (i.e. no 
 
 In edx-platform, there is also:
 
-* `CourseWaffleFlag`_: A WaffleFlag that adds override capabilities per course.
+* `CourseWaffleFlag`_: A WaffleFlag that adds override capabilities per course and per organization.
 * `ExperimentWaffleFlag`_: A somewhat complex CourseWaffleFlag that enables bucketing of users for A/B experiments.
 
 .. _WaffleFlag class: ../edx_toggles.toggles.internal.waffle.html#module-edx_toggles.toggles.internal.waffle


### PR DESCRIPTION
**Description:** 
`CourseWaffleFlag` org-level overrides were added in PR https://github.com/openedx/edx-platform/pull/29744 . This PR adds a mention of the new org-level override where the course-level override is currently mentioned in the documentation.

Work to add the org-level override counts to the toggle state report is underway - it will be completed in this ticket:
https://openedx.atlassian.net/browse/TNL-9513

**JIRA:**
https://openedx.atlassian.net/browse/TNL-8774

**Dependencies:** 
https://github.com/openedx/edx-platform/pull/29744

**Merge deadline:**
None

**Testing instructions:**

1. Read.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
None
