### PR TITLE
chore: upgrade python requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via django
 cffi==1.15.0
     # via pynacl
@@ -28,7 +28,7 @@ django-waffle==2.4.1
     # via
     #   -r requirements/base.in
     #   edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via -r requirements/base.in
 jinja2==3.1.2
     # via code-annotations
@@ -38,7 +38,7 @@ newrelic==7.10.0.175
     # via edx-django-utils
 pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3.3
+coverage==6.4
     # via codecov
 distlib==0.3.4
     # via virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/quality.txt
     #   django
@@ -13,13 +13,13 @@ astroid==2.11.5
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-atlassian-python-api==3.22.0
+atlassian-python-api==3.25.0
     # via -r requirements/quality.txt
 attrs==21.4.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -52,7 +52,7 @@ code-annotations==1.3.0
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -66,7 +66,7 @@ diff-cover==4.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.in
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -89,7 +89,7 @@ django-waffle==2.4.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.1
     # via -r requirements/dev.in
@@ -105,7 +105,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via inflect
 inflect==3.0.2
     # via
@@ -164,7 +164,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
 platformdirs==2.5.2
     # via
@@ -181,7 +181,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -201,7 +201,7 @@ pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
     # via diff-cover
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/quality.txt
     #   edx-lint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,11 +6,11 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-atlassian-python-api==3.22.0
+atlassian-python-api==3.25.0
     # via -r requirements/test.txt
 attrs==21.4.0
     # via
@@ -20,9 +20,9 @@ babel==2.10.1
     # via sphinx
 bleach==5.0.0
     # via readme-renderer
-build==0.7.0
+build==0.8.0
     # via -r requirements/doc.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -43,7 +43,7 @@ code-annotations==1.3.0
     # via -r requirements/test.txt
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -65,7 +65,7 @@ django-waffle==2.4.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-doc8==0.11.1
+doc8==0.11.2
     # via -r requirements/doc.in
 docutils==0.17.1
     # via
@@ -73,7 +73,7 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
@@ -83,7 +83,7 @@ idna==3.3
     #   requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   keyring
     #   sphinx
@@ -97,7 +97,7 @@ jinja2==3.1.2
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-keyring==23.5.0
+keyring==23.5.1
     # via twine
 markupsafe==2.1.1
     # via
@@ -130,7 +130,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -198,7 +198,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.4.1
+rich==12.4.4
     # via twine
 six==1.16.0
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,10 +8,8 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.4
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
+pip==22.1.1
+    # via -r requirements/pip.in
 setuptools==59.8.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -12,13 +12,13 @@ astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery
-atlassian-python-api==3.22.0
+atlassian-python-api==3.25.0
     # via -r requirements/test.txt
 attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -43,7 +43,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -51,7 +51,7 @@ deprecated==1.2.13
     # via
     #   -r requirements/test.txt
     #   atlassian-python-api
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
 django==3.2.13
     # via
@@ -67,7 +67,7 @@ django-waffle==2.4.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via -r requirements/test.txt
 edx-lint==5.2.2
     # via -r requirements/quality.in
@@ -118,7 +118,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -134,7 +134,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-atlassian-python-api==3.22.0
+atlassian-python-api==3.25.0
     # via -r requirements/scripts.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 cffi==1.15.0
     # via
@@ -43,7 +43,7 @@ django-waffle==2.4.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via -r requirements/base.txt
 idna==3.3
     # via requests
@@ -67,7 +67,7 @@ pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,16 +4,16 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   django
-atlassian-python-api==3.22.0
+atlassian-python-api==3.25.0
     # via -r requirements/scripts.txt
 attrs==21.4.0
     # via pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/scripts.txt
     #   requests
@@ -37,7 +37,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   -r requirements/test.in
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via pytest-cov
 deprecated==1.2.13
     # via
@@ -59,7 +59,7 @@ django-waffle==2.4.1
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   edx-django-utils
-edx-django-utils==4.8.1
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
@@ -98,7 +98,7 @@ pbr==5.9.0
     #   stevedore
 pluggy==1.0.0
     # via pytest
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt


### PR DESCRIPTION
### Description
- Ran `make upgrade` locally to fix the issue with `pip` and `pip-tools` version conflict when running the requirements upgrade job through GitHub Actions.