### PR TITLE
fix: remove zip constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via django
 cffi==1.15.1
     # via pynacl
@@ -46,7 +46,7 @@ pynacl==1.5.0
     # via edx-django-utils
 python-slugify==7.0.0
     # via code-annotations
-pytz==2022.6
+pytz==2022.7
     # via django
 pyyaml==6.0
     # via code-annotations

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,11 +10,11 @@ charset-normalizer==2.1.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.5.0
+coverage==7.0.3
     # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 packaging==22.0
     # via tox
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -34,7 +34,7 @@ six==1.16.0
     # via tox
 tomli==2.0.1
     # via tox
-tox==3.27.1
+tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
  
-# zipp > 1.2.0 does not work with Python 3.5
-zipp<=1.2.0
-
 # stevedore > 1.32.0 does not work with Python 3.5
 stevedore==1.32.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
@@ -13,9 +13,9 @@ astroid==2.12.13
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-atlassian-python-api==3.32.1
+atlassian-python-api==3.32.2
     # via -r requirements/quality.txt
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -56,7 +56,7 @@ code-annotations==1.3.0
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.5.0
+coverage[toml]==7.0.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -99,11 +99,11 @@ edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
 edx-lint==5.3.0
     # via -r requirements/quality.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -113,7 +113,7 @@ idna==3.4
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via inflect
 inflect==3.0.2
     # via
@@ -123,7 +123,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.10.1
+isort==5.11.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -135,7 +135,7 @@ jinja2==3.1.2
     #   jinja2-pluralize
 jinja2-pluralize==0.3.0
     # via diff-cover
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via
     #   -r requirements/quality.txt
     #   astroid
@@ -174,9 +174,9 @@ pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pip-tools==6.11.0
+pip-tools==6.12.1
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -205,11 +205,11 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydocstyle==6.1.1
+pydocstyle==6.2.2
     # via -r requirements/quality.txt
-pygments==2.13.0
+pygments==2.14.0
     # via diff-cover
-pylint==2.15.8
+pylint==2.15.9
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -246,7 +246,7 @@ python-slugify==7.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.6
+pytz==2022.7
     # via
     #   -r requirements/quality.txt
     #   django
@@ -307,7 +307,7 @@ tomlkit==0.11.6
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.27.1
+tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
@@ -338,10 +338,8 @@ wrapt==1.11.0
     #   -r requirements/quality.txt
     #   astroid
     #   deprecated
-zipp==1.2.0
-    # via
-    #   -c requirements/constraints.txt
-    #   importlib-metadata
+zipp==3.11.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,13 +6,13 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-atlassian-python-api==3.32.1
+atlassian-python-api==3.32.2
     # via -r requirements/test.txt
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -29,7 +29,6 @@ certifi==2022.12.7
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==2.1.1
     # via
@@ -44,12 +43,10 @@ code-annotations==1.3.0
     # via -r requirements/test.txt
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.5.0
+coverage[toml]==7.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.4
-    # via secretstorage
 deprecated==1.2.13
     # via
     #   -r requirements/test.txt
@@ -68,7 +65,7 @@ django-waffle==3.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-doc8==1.0.0
+doc8==1.1.1
     # via -r requirements/doc.in
 docutils==0.19
     # via
@@ -80,7 +77,7 @@ edx-django-utils==5.2.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -90,27 +87,25 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.0.0
     # via
     #   keyring
     #   sphinx
     #   twine
+importlib-resources==5.10.2
+    # via keyring
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
 markupsafe==2.1.1
     # via
@@ -139,7 +134,7 @@ pbr==5.11.0
     #   stevedore
 pep517==0.13.0
     # via build
-pkginfo==1.9.2
+pkginfo==1.9.4
     # via twine
 pluggy==1.0.0
     # via
@@ -153,7 +148,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   doc8
     #   readme-renderer
@@ -176,7 +171,7 @@ python-slugify==7.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.6
+pytz==2022.7
     # via
     #   -r requirements/test.txt
     #   babel
@@ -205,10 +200,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.0.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -218,7 +211,7 @@ six==1.16.0
     #   stevedore
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.3.0
+sphinx==6.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -273,7 +266,7 @@ wrapt==1.11.0
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   deprecated
-zipp==1.2.0
+zipp==3.11.0
     # via
-    #   -c requirements/constraints.txt
     #   importlib-metadata
+    #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ packaging==22.0
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.11.0
+pip-tools==6.12.1
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -12,9 +12,9 @@ astroid==2.12.13
     # via
     #   pylint
     #   pylint-celery
-atlassian-python-api==3.32.1
+atlassian-python-api==3.32.2
     # via -r requirements/test.txt
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -43,7 +43,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.5.0
+coverage[toml]==7.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -71,7 +71,7 @@ edx-django-utils==5.2.0
     # via -r requirements/test.txt
 edx-lint==5.3.0
     # via -r requirements/quality.in
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -83,7 +83,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.10.1
+isort==5.11.4
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -91,7 +91,7 @@ jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
 markupsafe==2.1.1
     # via
@@ -116,7 +116,7 @@ pbr==5.11.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via pylint
 pluggy==1.0.0
     # via
@@ -132,9 +132,9 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydocstyle==6.1.1
+pydocstyle==6.2.2
     # via -r requirements/quality.in
-pylint==2.15.8
+pylint==2.15.9
     # via
     #   edx-lint
     #   pylint-celery
@@ -165,7 +165,7 @@ python-slugify==7.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.6
+pytz==2022.7
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-atlassian-python-api==3.32.1
+atlassian-python-api==3.32.2
     # via -r requirements/scripts.in
 certifi==2022.12.7
     # via requests
@@ -83,7 +83,7 @@ python-slugify==7.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2022.6
+pytz==2022.7
     # via
     #   -r requirements/base.txt
     #   django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,14 +4,14 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   django
-atlassian-python-api==3.32.1
+atlassian-python-api==3.32.2
     # via -r requirements/scripts.txt
-attrs==22.1.0
+attrs==22.2.0
     # via pytest
 certifi==2022.12.7
     # via
@@ -37,7 +37,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   -r requirements/test.in
-coverage[toml]==6.5.0
+coverage[toml]==7.0.3
     # via pytest-cov
 deprecated==1.2.13
     # via
@@ -63,7 +63,7 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 idna==3.4
     # via
@@ -128,7 +128,7 @@ python-slugify==7.0.0
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt
     #   code-annotations
-pytz==2022.6
+pytz==2022.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/scripts.txt


### PR DESCRIPTION
### Description
- `zip` constraint causing requirements upgrade [job](https://github.com/openedx/edx-toggles/actions/runs/3852261608/jobs/6564238268) to fail due to constraints conflict. 
- Removed the `zip` constraint which was added for `Python 3.5` support and is not needed anymore.