### PR TITLE
fix: log error on waffle name with blank space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Log error on waffle object creation when name includes a blank space as a prefix or suffix.
+
 [5.3.0] - 2025-02-14
 --------------------
 

--- a/edx_toggles/toggles/internal/waffle/base.py
+++ b/edx_toggles/toggles/internal/waffle/base.py
@@ -2,7 +2,11 @@
 Base waffle toggle classes.
 """
 
+import logging
+
 from ..base import BaseToggle
+
+logger = logging.getLogger(__name__)
 
 
 class BaseWaffle(BaseToggle):
@@ -30,7 +34,9 @@ class BaseWaffle(BaseToggle):
         """
         if "." not in name:
             raise ValueError(
-                "Cannot create non-namespaced '{}' {} instance".format(
-                    name, cls.__name__
-                )
+                f"Cannot create non-namespaced '{name}' {cls.__name__} instance"
+            )
+        if name.startswith(" ") or name.endswith(" "):
+            logger.error(
+                f"{cls.__name__} instance name should not include a blank space prefix or suffix: '{name}'"
             )


### PR DESCRIPTION
Close #389.

@robrap is this what you had in mind in the issue you created? Crashing with a ValueError may be too radical. Do you think we should just log an error?