### PR TITLE
docs: update edx.rtd links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Library and utilities for implementing and reporting on feature toggles.
 
 Documentation is on `Read the Docs`_.  Code repository is on `GitHub`_.
 
-.. _Read the Docs: https://edx.readthedocs.io/projects/edx-toggles/en/latest/readme.html
+.. _Read the Docs: https://docs.openedx.org/projects/edx-toggles/en/latest/readme.html
 .. _GitHub: https://github.com/openedx/edx-toggles
 
 See the `scripts README`_ for more information on the scripts for reporting on the status of

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
   name: 'edx-toggles'
   description: "Library and utilities for Open edX feature toggles"
   links:
-    - url: "https://edx.readthedocs.io/projects/edx-toggles/en/latest/"
+    - url: "https://docs.openedx.org/projects/edx-toggles/en/latest/"
       title: "Documentation"
       icon: "Web"
   annotations:

--- a/docs/how_to/adding_new_ida_to_toggle_report.rst
+++ b/docs/how_to/adding_new_ida_to_toggle_report.rst
@@ -36,7 +36,7 @@ Steps required (2-4 hours):
 
     You can follow similar steps to use the settings Sphinx extension to publish non-boolean non-toggle setting annotations as well.
 
-.. _readthedocs documention for edx-platform feature toggles: https://edx.readthedocs.io/projects/edx-platform-technical/en/latest/featuretoggles.html
+.. _readthedocs documention for edx-platform feature toggles: https://docs.openedx.org/projects/edx-platform/en/latest/references/featuretoggles.html
 .. _annotated toggles in the edx-platform codebase: https://github.com/openedx/edx-platform/search?q=toggle_name
 .. _search for featuretoggles in edx-platform: https://github.com/openedx/edx-platform/search?q=featuretoggles
 
@@ -66,10 +66,10 @@ Steps required (2-4 hours):
 
     - (Optional) If your IDA has custom toggle types, you can subclass and override the reporting methods as was done in the edx-platform `example toggles state endpoint view`_.
 
-.. _ToggleStateReport: https://edx.readthedocs.io/projects/edx-toggles/en/latest/edx_toggles.toggles.state.internal.html#module-edx_toggles.toggles.state.internal.report
+.. _ToggleStateReport: https://docs.openedx.org/projects/edx-toggles/en/latest/edx_toggles.toggles.state.internal.html#module-edx_toggles.toggles.state.internal.report
 .. _example toggles state endpoint view: https://github.com/openedx/edx-platform/blob/650b0c1/openedx/core/djangoapps/waffle_utils/views.py#L50-L66
 .. _example urls.py in edx-platform: https://github.com/openedx/edx-platform/blob/650b0c13603468d33e3e629ef1e36acc8fefd683/openedx/core/djangoapps/waffle_utils/urls.py
-.. _supported toggle classes from edx-toggles: https://edx.readthedocs.io/projects/edx-toggles/en/latest/how_to/implement_the_right_toggle_type.html#implementing-the-right-toggle-class
+.. _supported toggle classes from edx-toggles: https://docs.openedx.org/projects/edx-toggles/en/latest/how_to/implement_the_right_toggle_type.html#implementing-the-right-toggle-class
 
 Toggles State Reports Spreadsheet
 =================================


### PR DESCRIPTION
We migrated the edx-toggles documentation to docs.openedx.org, so update the URLs appropriately.
