### PR TITLE
fix: Add cms GitHub URL to configuration

### DIFF
--- a/scripts/configuration.yaml
+++ b/scripts/configuration.yaml
@@ -1,5 +1,7 @@
 ida:
   lms:
     github_url: https://github.com/openedx/edx-platform
+  cms:
+    github_url: https://github.com/openedx/edx-platform
   credentials:
     github_url: https://github.com/openedx/credentials


### PR DESCRIPTION
**Description**

The [configuration.yaml] file only had LMS configuration but was missing CMS configuration, preventing the toggle annotation scripts from properly processing CMS feature toggles from the edx-platform repository.

**Fix:**

- `Added CMS configuration to the YAML file.`

This enables the annotation processing scripts to recognize and handle CMS as a separate IDA while pointing to the same edx-platform repository, completing the CMS integration for toggle reporting.

**Ticket**
https://2u-internal.atlassian.net/browse/BOM2-21

**Addition in Jenkins Job Script**
https://github.com/edx/jenkins-job-dsl-internal/pull/942

**Addition of cms configurations in feature-toggle-report-generator**
PR reference: https://github.com/edx/edx-internal/pull/13003